### PR TITLE
Add one new action to establish baremetal server eCPI environment

### DIFF
--- a/action/concrete_factory.go
+++ b/action/concrete_factory.go
@@ -6,6 +6,7 @@ import (
 
 	sl "github.com/maximilien/softlayer-go/softlayer"
 
+	bslcbm "github.com/maximilien/bosh-softlayer-cpi/softlayer/baremetal"
 	bslcstem "github.com/maximilien/bosh-softlayer-cpi/softlayer/stemcell"
 	bslcvm "github.com/maximilien/bosh-softlayer-cpi/softlayer/vm"
 )
@@ -32,6 +33,9 @@ func NewConcreteFactory(softLayerClient sl.Client, options ConcreteFactoryOption
 		logger,
 	)
 
+	bmCreator := bslcbm.NewBaremetalCreator(softLayerClient, logger)
+	bmFinder := bslcbm.NewBaremetalFinder(softLayerClient, logger)
+
 	return concreteFactory{
 		availableActions: map[string]Action{
 			// Stemcell management
@@ -51,6 +55,8 @@ func NewConcreteFactory(softLayerClient sl.Client, options ConcreteFactoryOption
 			"delete_disk": NewDeleteDisk(nil),
 			"attach_disk": NewAttachDisk(vmFinder, nil),
 			"detach_disk": NewDetachDisk(vmFinder, nil),
+
+			"establish_bare_metal_env": NewEstablishBareMetalEnv(bmCreator, bmFinder),
 
 			// Not implemented (disk related):
 			//   snapshot_disk

--- a/action/establish_bare_metal_env.go
+++ b/action/establish_bare_metal_env.go
@@ -1,0 +1,81 @@
+package action
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	bosherr "github.com/cloudfoundry/bosh-agent/errors"
+	bm "github.com/maximilien/bosh-softlayer-cpi/softlayer/baremetal"
+)
+
+const (
+	MEMORY_CON     = "SL_BARE_METAL_MEMORY"
+	PROCESSOR_CON  = "SL_BARE_METAL_PROCESSOR"
+	DISK_CON       = "SL_BARE_METAL_DISK"
+	HOST_CON       = "SL_BARE_METAL_HOST"
+	DOMAIN_CON     = "SL_BARE_METAL_DOMAIN"
+	OS_CON         = "SL_BARE_METAL_OS"
+	DATACENTER_CON = "SL_DATA_CENTER"
+
+	MAX_RETRIES = 120
+)
+
+type EstablishBareMetalEnv struct {
+	bmCreator bm.BaremetalCreator
+	bmFinder  bm.BaremetalFinder
+}
+
+func NewEstablishBareMetalEnv(bmCreator bm.BaremetalCreator, bmFinder bm.BaremetalFinder) EstablishBareMetalEnv {
+	return EstablishBareMetalEnv{
+		bmCreator: bmCreator,
+		bmFinder:  bmFinder,
+	}
+}
+
+func (b EstablishBareMetalEnv) Run() (interface{}, error) {
+
+	// Step #1, use baremetal creator to create a new baremetal server
+	memoryS := os.Getenv(MEMORY_CON)
+	processorS := os.Getenv(PROCESSOR_CON)
+	disksizeS := os.Getenv(DISK_CON)
+	host := os.Getenv(HOST_CON)
+	domain := os.Getenv(DOMAIN_CON)
+	ostype := os.Getenv(OS_CON)
+	datacenter := os.Getenv(DATACENTER_CON)
+
+	memory, err := strconv.Atoi(memoryS)
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Invalid baremetal creation memory parameter: %s", memoryS)
+	}
+
+	processor, err := strconv.Atoi(processorS)
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Invalid baremetal creation processor parameter: %s", processorS)
+	}
+
+	disksize, err := strconv.Atoi(disksizeS)
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Invalid baremetal creation disk size parameter: %s", disksizeS)
+	}
+
+	baremetal, err := b.bmCreator.Create(memory, processor, disksize, host, domain, ostype, datacenter)
+	if err != nil {
+		return nil, bosherr.WrapError(err, "Create baremetal server error")
+	}
+
+	for step := 1; baremetal.ProvisionDate == nil || step >= MAX_RETRIES; step++ {
+		time.Sleep(60 * time.Second)
+
+		baremetal, err = b.bmFinder.Find(baremetal.GlobalIdentifier)
+		if err != nil {
+			return nil, bosherr.WrapError(err, "Can not find the baremetal server of id: %s", baremetal.GlobalIdentifier)
+		}
+	}
+
+	if baremetal.ProvisionDate == nil {
+		return nil, bosherr.WrapError(err, "Baremetal server creation timeout")
+	}
+
+	return nil, nil
+}

--- a/bin/bare_metal
+++ b/bin/bare_metal
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -e
+
+export SL_BARE_METAL_FLAG=true
+export SL_BARE_METAL_MEMORY=2
+export SL_BARE_METAL_PROCESSOR=2
+export SL_BARE_METAL_DISK=20
+export SL_BARE_METAL_HOST=testing
+export SL_BARE_METAL_DOMAIN=softlayer.com
+export SL_BARE_METAL_OS=UBUNTU_LATEST
+export SL_DATA_CENTER=ams01
+
+./out/cpi -configPath dev/config.json < dev/establish_bare_metal_env.json

--- a/dev/establish_bare_metal_env.json
+++ b/dev/establish_bare_metal_env.json
@@ -1,0 +1,7 @@
+{
+	"method": "establish_bare_metal_env",
+	"arguments": [],
+	"context": {
+		"director_uuid": "3f695519-5a17-480f-879a-582dbe31131e"
+	}
+}

--- a/softlayer/baremetal/baremetal_creator.go
+++ b/softlayer/baremetal/baremetal_creator.go
@@ -1,0 +1,55 @@
+package baremetal
+
+import (
+	bosherr "github.com/cloudfoundry/bosh-agent/errors"
+	boshlog "github.com/cloudfoundry/bosh-agent/logger"
+	datatypes "github.com/maximilien/softlayer-go/data_types"
+	sl "github.com/maximilien/softlayer-go/softlayer"
+)
+
+const bmCreatorLogTag = "BaremetalCreator"
+
+type BaremetalCreator struct {
+	client sl.Client
+	logger boshlog.Logger
+}
+
+func NewBaremetalCreator(
+	client sl.Client,
+	logger boshlog.Logger,
+) BaremetalCreator {
+	return BaremetalCreator{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (c BaremetalCreator) Create(memory int, processor int, disksize int, host string, domain string, ostype string, datacenter string) (datatypes.SoftLayer_Hardware, error) {
+	c.logger.Debug(bmCreatorLogTag, "Creating baremetal %s.%s of %s with memory: %d, processors: %d, disk size '%d'", host, domain, ostype, memory, processor, disksize)
+
+	service, err := c.client.GetSoftLayer_Hardware_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, bosherr.WrapError(err, "Get hardware service error")
+	}
+
+	template := datatypes.SoftLayer_Hardware_Template{
+		Hostname:                     host,
+		Domain:                       domain,
+		ProcessorCoreAmount:          processor,
+		MemoryCapacity:               memory,
+		HourlyBillingFlag:            true,
+		OperatingSystemReferenceCode: ostype,
+
+		Datacenter: &datatypes.Datacenter{
+			Name: datacenter,
+		},
+	}
+
+	baremetal, err := service.CreateObject(template)
+
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, bosherr.WrapError(err, "Create baremetal error")
+	}
+
+	return baremetal, nil
+}

--- a/softlayer/baremetal/baremetal_creator_test.go
+++ b/softlayer/baremetal/baremetal_creator_test.go
@@ -1,0 +1,40 @@
+package baremetal_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	boshlog "github.com/cloudfoundry/bosh-agent/logger"
+	common "github.com/maximilien/bosh-softlayer-cpi/common"
+	bm "github.com/maximilien/bosh-softlayer-cpi/softlayer/baremetal"
+	fakeslclient "github.com/maximilien/softlayer-go/client/fakes"
+)
+
+var _ = Describe("BaremetalCreator", func() {
+	var (
+		softLayerClient *fakeslclient.FakeSoftLayerClient
+		logger          boshlog.Logger
+		creator         bm.BaremetalCreator
+	)
+
+	BeforeEach(func() {
+		softLayerClient = fakeslclient.NewFakeSoftLayerClient("fake-username", "fake-api-key")
+		logger = boshlog.NewLogger(boshlog.LevelNone)
+
+		creator = bm.NewBaremetalCreator(
+			softLayerClient,
+			logger,
+		)
+		common.SetTestFixtureForFakeSoftLayerClient(softLayerClient, "SoftLayer_Hardware_Service_createObject.json")
+	})
+
+	Describe("Create", func() {
+		Context("succeeded", func() {
+			It("returns a new Softlayer Hardware without an error", func() {
+				baremetal, err := creator.Create(2, 1, 10, "fake-host", "fake-domain", "fake-os", "fake-data-center")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(baremetal.GlobalIdentifier).To(Equal("fake-id"))
+			})
+		})
+	})
+})

--- a/softlayer/baremetal/baremetal_finder.go
+++ b/softlayer/baremetal/baremetal_finder.go
@@ -1,0 +1,31 @@
+package baremetal
+
+import (
+	bosherr "github.com/cloudfoundry/bosh-agent/errors"
+	boshlog "github.com/cloudfoundry/bosh-agent/logger"
+	datatypes "github.com/maximilien/softlayer-go/data_types"
+	sl "github.com/maximilien/softlayer-go/softlayer"
+)
+
+type BaremetalFinder struct {
+	client sl.Client
+	logger boshlog.Logger
+}
+
+func NewBaremetalFinder(client sl.Client, logger boshlog.Logger) BaremetalFinder {
+	return BaremetalFinder{client: client, logger: logger}
+}
+
+func (f BaremetalFinder) Find(id string) (datatypes.SoftLayer_Hardware, error) {
+	service, err := f.client.GetSoftLayer_Hardware_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, bosherr.WrapError(err, "Get hardware service error")
+	}
+
+	baremetal, err := service.GetObject(id)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, bosherr.WrapError(err, "Get baremetal error")
+	}
+
+	return baremetal, nil
+}

--- a/softlayer/baremetal/baremetal_finder_test.go
+++ b/softlayer/baremetal/baremetal_finder_test.go
@@ -1,0 +1,40 @@
+package baremetal_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	boshlog "github.com/cloudfoundry/bosh-agent/logger"
+	common "github.com/maximilien/bosh-softlayer-cpi/common"
+	bm "github.com/maximilien/bosh-softlayer-cpi/softlayer/baremetal"
+	fakeslclient "github.com/maximilien/softlayer-go/client/fakes"
+)
+
+var _ = Describe("BaremetalFinder", func() {
+	var (
+		softLayerClient *fakeslclient.FakeSoftLayerClient
+		logger          boshlog.Logger
+		finder          bm.BaremetalFinder
+	)
+
+	BeforeEach(func() {
+		softLayerClient = fakeslclient.NewFakeSoftLayerClient("fake-username", "fake-api-key")
+		logger = boshlog.NewLogger(boshlog.LevelNone)
+
+		finder = bm.NewBaremetalFinder(
+			softLayerClient,
+			logger,
+		)
+		common.SetTestFixtureForFakeSoftLayerClient(softLayerClient, "SoftLayer_Hardware_Service_getObject.json")
+	})
+
+	Describe("Find", func() {
+		Context("succeeded", func() {
+			It("returns a new Softlayer Hardware without an error", func() {
+				baremetal, err := finder.Find("fake-id")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(baremetal.GlobalIdentifier).To(Equal("fake-id"))
+			})
+		})
+	})
+})

--- a/softlayer/baremetal/baremetal_suite_test.go
+++ b/softlayer/baremetal/baremetal_suite_test.go
@@ -1,0 +1,13 @@
+package baremetal_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestBaremetal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Baremetal Suite")
+}

--- a/test_fixtures/softlayer/SoftLayer_Hardware_Service_createObject.json
+++ b/test_fixtures/softlayer/SoftLayer_Hardware_Service_createObject.json
@@ -1,0 +1,26 @@
+{
+	"accountId": 1,
+	"bareMetalInstanceFlag": 1,
+	"domain": "fake.com",
+	"fullyQualifiedDomainName": "fake",
+	"hardwareStatusId": 1,
+	"hostname":"fake-name",
+	"id": 1,
+	"manufacturerSerialNumber": "fake-number",
+	"notes": "fake-notes",
+	"provisionDate":"2014-11-30T23:20:47-08:00",
+	"serialNumber": "fake-sn",
+	"serviceProviderId": 1,
+	"serviceProviderResourceId": 1,
+	"globalIdentifier": "fake-id",
+	"hardwareFunction":
+		{
+			"code": "fake-code",
+			"description": "fake-description",
+			"id": 1
+		},
+	"networkManagementIpAddress": "1.1.1.1",
+	"primaryBackendIpAddress": "1.1.1.1",
+	"primaryIpAddress": "1.1.1.1",
+	"privateIpAddress": "2.2.2.2"
+}

--- a/test_fixtures/softlayer/SoftLayer_Hardware_Service_getObject.json
+++ b/test_fixtures/softlayer/SoftLayer_Hardware_Service_getObject.json
@@ -1,0 +1,26 @@
+{
+	"accountId": 1,
+	"bareMetalInstanceFlag": 1,
+	"domain": "fake.com",
+	"fullyQualifiedDomainName": "fake",
+	"hardwareStatusId": 1,
+	"hostname":"fake-name",
+	"id": 1,
+	"manufacturerSerialNumber": "fake-number",
+	"notes": "fake-notes",
+	"provisionDate":"2014-11-30T23:20:47-08:00",
+	"serialNumber": "fake-sn",
+	"serviceProviderId": 1,
+	"serviceProviderResourceId": 1,
+	"globalIdentifier": "fake-id",
+	"hardwareFunction":
+		{
+			"code": "fake-code",
+			"description": "fake-description",
+			"id": 1
+		},
+	"networkManagementIpAddress": "1.1.1.1",
+	"primaryBackendIpAddress": "1.1.1.1",
+	"primaryIpAddress": "1.1.1.1",
+	"privateIpAddress": "2.2.2.2"
+}


### PR DESCRIPTION
In this patch, we added the following features:

1. Add a new action named "establish_bare_metal_env" to set up a eCPI env on a newly created bare_metal server.

2. Finished the first step of "establish_bare_metal_env" action which is to use softlayer-go's hardware service to create a new baremetal server.

Signed-off-by: xingzhou <xingzhou@cn.ibm.com>