### PR TITLE
Add BlockDevice parameters when creating virtual guest

### DIFF
--- a/softlayer/vm/interface.go
+++ b/softlayer/vm/interface.go
@@ -14,6 +14,8 @@ type VMCloudProperties struct {
 	Datacenter               sldatatypes.Datacenter
 	BlockDeviceTemplateGroup sldatatypes.BlockDeviceTemplateGroup
 	SshKeys                  []sldatatypes.SshKey `json:"sshKeys"`
+	RootDiskSize             int                  `json:"rootDiskSize,omitempty"`
+	EphemeralDiskSize        int                  `json:"ephemeralDiskSize,omitempty"`
 }
 
 type VMMetadata struct {

--- a/softlayer/vm/softlayer_creator.go
+++ b/softlayer/vm/softlayer_creator.go
@@ -51,6 +51,20 @@ func (c SoftLayerCreator) Create(agentID string, stemcell bslcstem.Stemcell, clo
 		BlockDeviceTemplateGroup: &sldatatypes.BlockDeviceTemplateGroup{
 			GlobalIdentifier: stemcell.Uuid(),
 		},
+		BlockDevices: []sldatatypes.BlockDevice{
+			sldatatypes.BlockDevice{
+				Device: "0",
+				DiskImage: sldatatypes.DiskImage{
+					Capacity: cloudProps.RootDiskSize,
+				},
+			},
+			sldatatypes.BlockDevice{
+				Device: "2",
+				DiskImage: sldatatypes.DiskImage{
+					Capacity: cloudProps.EphemeralDiskSize,
+				},
+			},
+		},
 		SshKeys:           cloudProps.SshKeys,
 		HourlyBillingFlag: true,
 		LocalDiskFlag:     true,

--- a/softlayer/vm/softlayer_creator_test.go
+++ b/softlayer/vm/softlayer_creator_test.go
@@ -63,7 +63,9 @@ var _ = Describe("SoftLayerCreator", func() {
 					BlockDeviceTemplateGroup: sldatatypes.BlockDeviceTemplateGroup{
 						GlobalIdentifier: "fake-uuid",
 					},
-					Datacenter: sldatatypes.Datacenter{Name: "fake-datacenter"},
+					RootDiskSize:      25,
+					EphemeralDiskSize: 25,
+					Datacenter:        sldatatypes.Datacenter{Name: "fake-datacenter"},
 				}
 				networks = Networks{}
 				env = Environment{}
@@ -109,10 +111,37 @@ var _ = Describe("SoftLayerCreator", func() {
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("fails when VMProperties is missing MaxMemory", func() {
+				It("fails when VMProperties is missing Domain", func() {
 					cloudProps = VMCloudProperties{
 						StartCpus: 4,
 						MaxMemory: 1024,
+					}
+
+					_, err := creator.Create(agentID, stemcell, cloudProps, networks, env)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("fails when RootDiskSize is negative", func() {
+					cloudProps = VMCloudProperties{
+						StartCpus:    4,
+						MaxMemory:    1024,
+						Domain:       "fake-domain",
+						Datacenter:   sldatatypes.Datacenter{Name: "fake-datacenter"},
+						RootDiskSize: -100,
+					}
+
+					_, err := creator.Create(agentID, stemcell, cloudProps, networks, env)
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("fails when Ephemeral DiskSize is negative", func() {
+					cloudProps = VMCloudProperties{
+						StartCpus:         4,
+						MaxMemory:         1024,
+						Domain:            "fake-domain",
+						Datacenter:        sldatatypes.Datacenter{Name: "fake-datacenter"},
+						RootDiskSize:      100,
+						EphemeralDiskSize: -100,
 					}
 
 					_, err := creator.Create(agentID, stemcell, cloudProps, networks, env)


### PR DESCRIPTION
When creating virtual guest, user need to specify the disk size for root disk and ephemeral disk now.
These two new options are required and set in VMCloudProperties

This patch is cooperating with https://github.com/maximilien/softlayer-go/pull/19 in softlayer-go project

Signed-off-by: Edward Zhang <zhuadl@cn.ibm.com>