### PR TITLE
Ephemeral disk

### DIFF
--- a/softlayer/vm/agent_env.go
+++ b/softlayer/vm/agent_env.go
@@ -70,7 +70,7 @@ func NewAgentEnvFromJSON(bytes []byte) (AgentEnv, error) {
 	return agentEnv, nil
 }
 
-func NewAgentEnvForVM(agentID, vmCID string, networks Networks, env Environment, agentOptions AgentOptions) AgentEnv {
+func NewAgentEnvForVM(agentID, vmCID string, networks Networks, disksSpec DisksSpec, env Environment, agentOptions AgentOptions) AgentEnv {
 	networksSpec := NetworksSpec{}
 
 	for netName, network := range networks {
@@ -106,9 +106,7 @@ func NewAgentEnvForVM(agentID, vmCID string, networks Networks, env Environment,
 			Options:  agentOptions.Blobstore.Options,
 		},
 
-		Disks: DisksSpec{
-			Ephemeral: "/dev/xvdc",
-		},
+		Disks: disksSpec,
 
 		Networks: networksSpec,
 

--- a/softlayer/vm/agent_env.go
+++ b/softlayer/vm/agent_env.go
@@ -46,6 +46,7 @@ type NetworkSpec struct {
 }
 
 type DisksSpec struct {
+	Ephemeral  string         `json:"ephemeral"`
 	Persistent PersistentSpec `json:"persistent"`
 }
 
@@ -103,6 +104,10 @@ func NewAgentEnvForVM(agentID, vmCID string, networks Networks, env Environment,
 		Blobstore: BlobstoreSpec{
 			Provider: agentOptions.Blobstore.Type,
 			Options:  agentOptions.Blobstore.Options,
+		},
+
+		Disks: DisksSpec{
+			Ephemeral: "/dev/xvdc",
 		},
 
 		Networks: networksSpec,

--- a/softlayer/vm/agent_env_for_vm_test.go
+++ b/softlayer/vm/agent_env_for_vm_test.go
@@ -26,6 +26,8 @@ var _ = Describe("NewAgentEnvForVM", func() {
 			},
 		}
 
+		disks := DisksSpec{Ephemeral: "/dev/xvdc"}
+
 		env := Environment{"fake-env-key": "fake-env-value"}
 
 		agentOptions := AgentOptions{
@@ -44,6 +46,7 @@ var _ = Describe("NewAgentEnvForVM", func() {
 			"fake-agent-id",
 			"fake-vm-id",
 			networks,
+			disks,
 			env,
 			agentOptions,
 		)
@@ -84,6 +87,10 @@ var _ = Describe("NewAgentEnvForVM", func() {
 						"fake-cp-key": "fake-cp-value",
 					},
 				},
+			},
+
+			Disks: DisksSpec{
+				Ephemeral: "/dev/xvdc",
 			},
 
 			Env: map[string]interface{}{

--- a/softlayer/vm/agent_env_from_json_test.go
+++ b/softlayer/vm/agent_env_from_json_test.go
@@ -34,9 +34,7 @@ var _ = Describe("NewAgentEnvFromJSON", func() {
         },
 
         "disks": {
-          "persistent": {
-            "fake-persistent-id": "fake-persistent-path"
-          }
+          "ephemeral": "/dev/xvdc"
         },
 
         "env": {"fake-env-key": "fake-env-value"}
@@ -68,9 +66,7 @@ var _ = Describe("NewAgentEnvFromJSON", func() {
 				},
 
 				Disks: DisksSpec{
-					Persistent: PersistentSpec{
-						"fake-persistent-id": "fake-persistent-path",
-					},
+					Ephemeral: "/dev/xvdc",
 				},
 
 				Env: map[string]interface{}{

--- a/softlayer/vm/softlayer_creator.go
+++ b/softlayer/vm/softlayer_creator.go
@@ -71,7 +71,10 @@ func (c SoftLayerCreator) Create(agentID string, stemcell bslcstem.Stemcell, clo
 		return SoftLayerVM{}, bosherr.WrapError(err, "Creating VirtualGuest from SoftLayer client")
 	}
 
-	agentEnv := NewAgentEnvForVM(agentID, strconv.Itoa(virtualGuest.Id), networks, env, c.agentOptions)
+	//TODO: need to find or ensure the name for the ephemeral disk for SoftLayer VG
+	disks := DisksSpec{Ephemeral: "/dev/xvdc"}
+
+	agentEnv := NewAgentEnvForVM(agentID, strconv.Itoa(virtualGuest.Id), networks, disks, env, c.agentOptions)
 
 	metadata, err := json.Marshal(agentEnv)
 	if err != nil {

--- a/softlayer/vm/softlayer_creator.go
+++ b/softlayer/vm/softlayer_creator.go
@@ -54,24 +54,6 @@ func (c SoftLayerCreator) Create(agentID string, stemcell bslcstem.Stemcell, clo
 			GlobalIdentifier: stemcell.Uuid(),
 		},
 
-		BlockDevices: []sldatatypes.BlockDevice{
-			// Device: 0 is root disk
-			sldatatypes.BlockDevice{
-				Device: "0",
-				DiskImage: sldatatypes.DiskImage{
-					Capacity: cloudProps.RootDiskSize,
-				},
-			},
-			// Device: 1 is pre-configured to swap
-			// Device: 2 is ephemeral disk
-			sldatatypes.BlockDevice{
-				Device: "2",
-				DiskImage: sldatatypes.DiskImage{
-					Capacity: cloudProps.EphemeralDiskSize,
-				},
-			},
-		},
-
 		SshKeys:           cloudProps.SshKeys,
 		HourlyBillingFlag: true,
 


### PR DESCRIPTION
Adds ephemeral disk support but incomplete in that it fixes the ephemeral disk name to `/dev/xvdc` and need to see if there is a way to determine the name.

/cc @xingzhou and @zhang-hua