### PR TITLE
support more properties in create_vm method

### DIFF
--- a/softlayer/vm/interface.go
+++ b/softlayer/vm/interface.go
@@ -8,14 +8,26 @@ import (
 )
 
 type VMCloudProperties struct {
-	Domain                   string `json:"domain,omitempty"`
-	StartCpus                int    `json:"startCpus,omitempty"`
-	MaxMemory                int    `json:"maxMemory,omitempty"`
-	Datacenter               sldatatypes.Datacenter
-	BlockDeviceTemplateGroup sldatatypes.BlockDeviceTemplateGroup
-	SshKeys                  []sldatatypes.SshKey `json:"sshKeys"`
-	RootDiskSize             int                  `json:"rootDiskSize,omitempty"`
-	EphemeralDiskSize        int                  `json:"ephemeralDiskSize,omitempty"`
+	Domain                   string                               `json:"domain,omitempty"`
+	StartCpus                int                                  `json:"startCpus,omitempty"`
+	MaxMemory                int                                  `json:"maxMemory,omitempty"`
+	Datacenter               sldatatypes.Datacenter               `json:"datacenter"`
+	BlockDeviceTemplateGroup sldatatypes.BlockDeviceTemplateGroup `json:"blockDeviceTemplateGroup,omitempty"`
+	SshKeys                  []sldatatypes.SshKey                 `json:"sshKeys"`
+	RootDiskSize             int                                  `json:"rootDiskSize,omitempty"`
+	EphemeralDiskSize        int                                  `json:"ephemeralDiskSize,omitempty"`
+
+	VmNamePrefix                   string                                     `json:"vmNamePrefix,omitempty"`
+	HourlyBillingFlag              bool                                       `json:"hourlyBillingFlag,omitempty"`
+	LocalDiskFlag                  bool                                       `json:"localDiskFlag,omitempty"`
+	DedicatedAccountHostOnlyFlag   bool                                       `json:"dedicatedAccountHostOnlyFlag,omitempty"`
+	NetworkComponents              []sldatatypes.NetworkComponents            `json:"networkComponents,omitempty"`
+	PrivateNetworkOnlyFlag         bool                                       `json:"privateNetworkOnlyFlag,omitempty"`
+	PrimaryNetworkComponent        sldatatypes.PrimaryNetworkComponent        `json:"primaryNetworkComponent,omitempty"`
+	PrimaryBackendNetworkComponent sldatatypes.PrimaryBackendNetworkComponent `json:"primaryBackendNetworkComponent,omitempty"`
+	BlockDevices                   []sldatatypes.BlockDevice                  `json:"blockDevices,omitempty"`
+	UserData                       []sldatatypes.UserData                     `json:"userData,omitempty"`
+	PostInstallScriptUri           string                                     `json:"postInstallScriptUri,omitempty"`
 }
 
 type VMMetadata map[string]interface{}

--- a/softlayer/vm/softlayer_creator_test.go
+++ b/softlayer/vm/softlayer_creator_test.go
@@ -63,9 +63,25 @@ var _ = Describe("SoftLayerCreator", func() {
 					BlockDeviceTemplateGroup: sldatatypes.BlockDeviceTemplateGroup{
 						GlobalIdentifier: "fake-uuid",
 					},
-					RootDiskSize:      25,
-					EphemeralDiskSize: 25,
-					Datacenter:        sldatatypes.Datacenter{Name: "fake-datacenter"},
+					RootDiskSize:                 25,
+					EphemeralDiskSize:            25,
+					Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
+					HourlyBillingFlag:            true,
+					LocalDiskFlag:                true,
+					VmNamePrefix:                 "bosh-",
+					PostInstallScriptUri:         "",
+					DedicatedAccountHostOnlyFlag: true,
+					PrivateNetworkOnlyFlag:       false,
+					SshKeys:                      []sldatatypes.SshKey{{Id: 74826}},
+					BlockDevices: []sldatatypes.BlockDevice{{
+						Device:    "0",
+						DiskImage: sldatatypes.DiskImage{Capacity: 100}}},
+					NetworkComponents: []sldatatypes.NetworkComponents{{MaxSpeed: 1000}},
+					PrimaryNetworkComponent: sldatatypes.PrimaryNetworkComponent{
+						NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+					PrimaryBackendNetworkComponent: sldatatypes.PrimaryBackendNetworkComponent{
+						NetworkVlan: sldatatypes.NetworkVlan{Id: 524956}},
+					UserData: []sldatatypes.UserData{{Value: "someValue"}},
 				}
 				networks = Networks{}
 				env = Environment{}


### PR DESCRIPTION
support more properties in create_vm method in softlayer/vm/softlayer_creator.go ,
and change  hostname to follow the Ruby version's hostname naming rules.
and check the conditional require properties situation. 