### PR TITLE
Make softlayer cpi compatible with bosh-init

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,98 +1,98 @@
 {
-	"ImportPath": "github.com/maximilien/bosh-softlayer-cpi",
-	"GoVersion": "go1.4.2",
-	"Packages": [
-		"./..."
-	],
-	"Deps": [
-		{
-			"ImportPath": "code.google.com/p/go.crypto/ssh",
-			"Comment": "null-236",
-			"Rev": "69e2a90ed92d03812364aeb947b7068dc42e561e"
-		},
-		{
-			"ImportPath": "github.com/cloudfoundry/bosh-utils/errors",
-			"Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
-		},
-		{
-			"ImportPath": "github.com/cloudfoundry/bosh-utils/fileutil",
-			"Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
-		},
-		{
-			"ImportPath": "github.com/cloudfoundry/bosh-utils/internal/github.com/cloudfoundry/gofileutils/glob",
-			"Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
-		},
-		{
-			"ImportPath": "github.com/cloudfoundry/bosh-utils/internal/github.com/nu7hatch/gouuid",
-			"Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
-		},
-		{
-			"ImportPath": "github.com/cloudfoundry/bosh-utils/logger",
-			"Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
-		},
-		{
-			"ImportPath": "github.com/cloudfoundry/bosh-utils/retrystrategy",
-			"Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
-		},
-		{
-			"ImportPath": "github.com/cloudfoundry/bosh-utils/system",
-			"Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
-		},
-		{
-			"ImportPath": "github.com/kr/fs",
-			"Rev": "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
-		},
-		{
-			"ImportPath": "github.com/maximilien/softlayer-go/client",
-			"Comment": "v0.2.0-190-g7e2435e",
-			"Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
-		},
-		{
-			"ImportPath": "github.com/maximilien/softlayer-go/common",
-			"Comment": "v0.2.0-190-g7e2435e",
-			"Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
-		},
-		{
-			"ImportPath": "github.com/maximilien/softlayer-go/data_types",
-			"Comment": "v0.2.0-190-g7e2435e",
-			"Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
-		},
-		{
-			"ImportPath": "github.com/maximilien/softlayer-go/services",
-			"Comment": "v0.2.0-190-g7e2435e",
-			"Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
-		},
-		{
-			"ImportPath": "github.com/maximilien/softlayer-go/softlayer",
-			"Comment": "v0.2.0-190-g7e2435e",
-			"Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
-		},
-		{
-			"ImportPath": "github.com/maximilien/softlayer-go/test_helpers",
-			"Comment": "v0.2.0-190-g7e2435e",
-			"Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
-		},
-		{
-			"ImportPath": "github.com/onsi/ginkgo",
-			"Comment": "v1.2.0-8-g25380c6",
-			"Rev": "25380c62e61d3f90436be125b8127dbae578fdef"
-		},
-		{
-			"ImportPath": "github.com/onsi/gomega",
-			"Comment": "v1.0-50-gd6c945f",
-			"Rev": "d6c945f9fdbf6cad99e85b0feff591caa268e0db"
-		},
-		{
-			"ImportPath": "github.com/pivotal-golang/clock",
-			"Rev": "3fd3c1944c59d9742e1cd333672181cd1a6f9fa0"
-		},
-		{
-			"ImportPath": "github.com/pkg/sftp",
-			"Rev": "d2d0a435b798a9af27f5fc597cacc19d275df702"
-		},
-		{
-			"ImportPath": "golang.org/x/crypto/ssh",
-			"Rev": "60052bd85f2d91293457e8811b0cf26b773de469"
-		}
-	]
+  "ImportPath": "github.com/maximilien/bosh-softlayer-cpi",
+  "GoVersion": "go1.4.2",
+  "Packages": [
+	"./..."
+  ],
+  "Deps": [
+	{
+	  "ImportPath": "code.google.com/p/go.crypto/ssh",
+	  "Comment": "null-236",
+	  "Rev": "69e2a90ed92d03812364aeb947b7068dc42e561e"
+	},
+	{
+	  "ImportPath": "github.com/cloudfoundry/bosh-utils/errors",
+	  "Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
+	},
+	{
+	  "ImportPath": "github.com/cloudfoundry/bosh-utils/fileutil",
+	  "Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
+	},
+	{
+	  "ImportPath": "github.com/cloudfoundry/bosh-utils/internal/github.com/cloudfoundry/gofileutils/glob",
+	  "Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
+	},
+	{
+	  "ImportPath": "github.com/cloudfoundry/bosh-utils/internal/github.com/nu7hatch/gouuid",
+	  "Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
+	},
+	{
+	  "ImportPath": "github.com/cloudfoundry/bosh-utils/logger",
+	  "Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
+	},
+	{
+	  "ImportPath": "github.com/cloudfoundry/bosh-utils/retrystrategy",
+	  "Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
+	},
+	{
+	  "ImportPath": "github.com/cloudfoundry/bosh-utils/system",
+	  "Rev": "6c266c2d546fc0dfec0f3c2b0728f87b06fcd25e"
+	},
+	{
+	  "ImportPath": "github.com/kr/fs",
+	  "Rev": "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+	},
+	{
+	  "ImportPath": "github.com/maximilien/softlayer-go/client",
+	  "Comment": "v0.2.0-190-g7e2435e",
+	  "Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
+	},
+	{
+	  "ImportPath": "github.com/maximilien/softlayer-go/common",
+	  "Comment": "v0.2.0-190-g7e2435e",
+	  "Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
+	},
+	{
+	  "ImportPath": "github.com/maximilien/softlayer-go/data_types",
+	  "Comment": "v0.2.0-190-g7e2435e",
+	  "Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
+	},
+	{
+	  "ImportPath": "github.com/maximilien/softlayer-go/services",
+	  "Comment": "v0.2.0-190-g7e2435e",
+	  "Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
+	},
+	{
+	  "ImportPath": "github.com/maximilien/softlayer-go/softlayer",
+	  "Comment": "v0.2.0-190-g7e2435e",
+	  "Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
+	},
+	{
+	  "ImportPath": "github.com/maximilien/softlayer-go/test_helpers",
+	  "Comment": "v0.2.0-190-g7e2435e",
+	  "Rev": "7e2435e588ce7fd474384954e711d6467c86addd"
+	},
+	{
+	  "ImportPath": "github.com/onsi/ginkgo",
+	  "Comment": "v1.2.0-8-g25380c6",
+	  "Rev": "25380c62e61d3f90436be125b8127dbae578fdef"
+	},
+	{
+	  "ImportPath": "github.com/onsi/gomega",
+	  "Comment": "v1.0-50-gd6c945f",
+	  "Rev": "d6c945f9fdbf6cad99e85b0feff591caa268e0db"
+	},
+	{
+	  "ImportPath": "github.com/pivotal-golang/clock",
+	  "Rev": "3fd3c1944c59d9742e1cd333672181cd1a6f9fa0"
+	},
+	{
+	  "ImportPath": "github.com/pkg/sftp",
+	  "Rev": "d2d0a435b798a9af27f5fc597cacc19d275df702"
+	},
+	{
+	  "ImportPath": "golang.org/x/crypto/ssh",
+	  "Rev": "60052bd85f2d91293457e8811b0cf26b773de469"
+	}
+  ]
 }

--- a/bin/build
+++ b/bin/build
@@ -6,7 +6,7 @@
   base=$( cd "$( dirname "$( dirname "$0" )")" && pwd )
   base_gopath=$( cd $base/../../../.. && pwd )
 
-  export GOPATH=$base/Godeps/_workspace:$base_gopath:$GOPATH
+  export GOPATH=$base_gopath:$GOPATH
 
   cd $base
   go build -o out/cpi github.com/maximilien/bosh-softlayer-cpi/main

--- a/dev/attach_disk.json
+++ b/dev/attach_disk.json
@@ -2,7 +2,7 @@
   "method": "attach_disk",
   "arguments": [
     "12702997",
-    "6615285"
+    "5665277"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/dev/attach_disk.json
+++ b/dev/attach_disk.json
@@ -1,8 +1,8 @@
 {
   "method": "attach_disk",
   "arguments": [
-    "10498259",
-    "5636345"
+    "12702997",
+    "6615285"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/dev/config.json
+++ b/dev/config.json
@@ -15,7 +15,7 @@
     "StemcellsDir": "/var/vcap/store/cpi/stemcells"
   },
   "SoftLayer": {
-    "username": "cuixuex@cn.ibm.com",
-    "apiKey": "88c500aed826ddb9f93b3d248fbb9104b84b0c6cc2c936127a01502f85499d15"
+    "username": "fake-username",
+    "apiKey": "fake-api-key"
   }
 }

--- a/dev/config.json
+++ b/dev/config.json
@@ -15,7 +15,7 @@
     "StemcellsDir": "/var/vcap/store/cpi/stemcells"
   },
   "SoftLayer": {
-    "username": "fake-username",
-    "apiKey": "fake-api-key"
+    "username": "cuixuex@cn.ibm.com",
+    "apiKey": "88c500aed826ddb9f93b3d248fbb9104b84b0c6cc2c936127a01502f85499d15"
   }
 }

--- a/dev/create_disk.json
+++ b/dev/create_disk.json
@@ -5,7 +5,7 @@
     {
       "consistent_performance_iscsi": true
     },
-    "10498259"
+    "13124007"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/dev/create_disk.json
+++ b/dev/create_disk.json
@@ -5,7 +5,7 @@
     {
       "consistent_performance_iscsi": true
     },
-    "13124007"
+    "10498259"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/dev/delete_disk.json
+++ b/dev/delete_disk.json
@@ -1,7 +1,7 @@
 {
   "method": "delete_disk",
   "arguments": [
-    "6946883"
+    "5665277"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/dev/delete_disk.json
+++ b/dev/delete_disk.json
@@ -1,7 +1,7 @@
 {
   "method": "delete_disk",
   "arguments": [
-    "5665277"
+    "6946883"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/dev/detach_disk.json
+++ b/dev/detach_disk.json
@@ -1,8 +1,8 @@
 {
   "method": "detach_disk",
   "arguments": [
-    "13069573",
-    "6772271"
+    "10498259",
+    "5636345"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/dev/detach_disk.json
+++ b/dev/detach_disk.json
@@ -1,8 +1,8 @@
 {
   "method": "detach_disk",
   "arguments": [
-    "10498259",
-    "5636345"
+    "13069573",
+    "6772271"
   ],
   "context": {
     "director_uuid": "5276b588-1016-4023-acae-9a0d797168be"

--- a/softlayer/vm/softlayer_creator.go
+++ b/softlayer/vm/softlayer_creator.go
@@ -1,7 +1,12 @@
 package vm
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
+	"text/template"
 	"time"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
@@ -11,6 +16,8 @@ import (
 
 	bslcommon "github.com/maximilien/bosh-softlayer-cpi/softlayer/common"
 	bslcstem "github.com/maximilien/bosh-softlayer-cpi/softlayer/stemcell"
+
+	boshsys "github.com/cloudfoundry/bosh-utils/system"
 
 	util "github.com/maximilien/bosh-softlayer-cpi/util"
 )
@@ -26,7 +33,7 @@ type SoftLayerCreator struct {
 }
 
 func NewSoftLayerCreator(softLayerClient sl.Client, agentEnvServiceFactory AgentEnvServiceFactory, agentOptions AgentOptions, logger boshlog.Logger) SoftLayerCreator {
-	bslcommon.TIMEOUT = 20 * time.Minute
+	bslcommon.TIMEOUT = 60 * time.Minute
 	bslcommon.POLLING_INTERVAL = 20 * time.Second
 	bslcommon.MAX_RETRY_COUNT = 5
 
@@ -67,8 +74,42 @@ func (c SoftLayerCreator) Create(agentID string, stemcell bslcstem.Stemcell, clo
 	}
 
 	agentEnvService := c.agentEnvServiceFactory.New(virtualGuest.Id)
-
 	vm := NewSoftLayerVM(virtualGuest.Id, c.softLayerClient, util.GetSshClient(), agentEnvService, c.logger, TIMEOUT_TRANSACTIONS_DELETE_VM)
+
+	if len(cloudProps.BoshIp) == 0 {
+		virtualGuest, err = bslcommon.GetObjectDetailsOnVirtualGuest(vm.softLayerClient, virtualGuest.Id)
+		if err != nil {
+			return SoftLayerVM{}, bosherr.WrapErrorf(err, "Can not get details from virtual guest with id: %d.", virtualGuest.Id)
+		}
+		c.updateEtcHostsOfBoshInit(fmt.Sprintf("%s  %s", virtualGuest.PrimaryBackendIpAddress, virtualGuest.FullyQualifiedDomainName))
+
+		// Update mbus url setting for bosh director
+		metadata, err := bslcommon.GetUserMetadataOnVirtualGuest(vm.softLayerClient, virtualGuest.Id)
+		if err != nil {
+			return SoftLayerVM{}, bosherr.WrapErrorf(err, "Can not get metadata from virtual guest with id: %d.", virtualGuest.Id)
+		}
+		agentEnv, err := NewAgentEnvFromJSON(metadata)
+		if err != nil {
+			return SoftLayerVM{}, bosherr.WrapErrorf(err, "Can not unmarshal metadata from virutal guest with id: %d.", virtualGuest.Id)
+		}
+
+		//Construct mbus url with new director ip
+		mbus, err := c.parseMbusURL(c.agentOptions.Mbus, virtualGuest.PrimaryBackendIpAddress)
+		if err != nil {
+			return SoftLayerVM{}, bosherr.WrapErrorf(err, "Can not construct mbus url.")
+		}
+		agentEnv.Mbus = mbus
+
+		metadata, err = json.Marshal(agentEnv)
+		if err != nil {
+			return SoftLayerVM{}, bosherr.WrapError(err, "Marshalling agent environment metadata")
+		}
+
+		err = bslcommon.ConfigureMetadataOnVirtualGuest(vm.softLayerClient, virtualGuest.Id, string(metadata), bslcommon.TIMEOUT, bslcommon.POLLING_INTERVAL)
+		if err != nil {
+			return SoftLayerVM{}, bosherr.WrapError(err, fmt.Sprintf("Configuring metadata on VirtualGuest `%d`", virtualGuest.Id))
+		}
+	}
 
 	return vm, nil
 }
@@ -93,3 +134,40 @@ func (c SoftLayerCreator) resolveNetworkIP(networks Networks) (string, error) {
 
 	return network.IP, nil
 }
+
+func (c SoftLayerCreator) parseMbusURL(mbusURL string, primaryBackendIpAddress string) (string, error) {
+	parsedURL, err := url.Parse(mbusURL)
+	if err != nil {
+		return "", bosherr.WrapError(err, "Parsing Mbus URL")
+	}
+	var username, password, port string
+	_, port, _ = net.SplitHostPort(parsedURL.Host)
+	userInfo := parsedURL.User
+	if userInfo != nil {
+		username = userInfo.Username()
+		password, _ = userInfo.Password()
+		return fmt.Sprintf("https://%s:%s@%s:%s", username, password, primaryBackendIpAddress, port), nil
+	} else {
+		return fmt.Sprintf("https://%s:%s", primaryBackendIpAddress, port), nil
+	}
+}
+
+func (c SoftLayerCreator) updateEtcHostsOfBoshInit(record string) (err error) {
+	buffer := bytes.NewBuffer([]byte{})
+	t := template.Must(template.New("etc-hosts").Parse(etcHostsTemplate))
+
+	err = t.Execute(buffer, record)
+	if err != nil {
+		return bosherr.WrapError(err, "Generating config from template")
+	}
+	fileSystem := boshsys.NewOsFileSystemWithStrictTempRoot(c.logger)
+	err = fileSystem.WriteFile("/etc/hosts", buffer.Bytes())
+	if err != nil {
+		return bosherr.WrapError(err, "Writing to /etc/hosts")
+	}
+	return nil
+}
+
+const etcHostsTemplate = `127.0.0.1 localhost
+{{.}}
+`

--- a/softlayer/vm/softlayer_creator_test.go
+++ b/softlayer/vm/softlayer_creator_test.go
@@ -64,6 +64,7 @@ var _ = Describe("SoftLayerCreator", func() {
 						GlobalIdentifier: "fake-uuid",
 					},
 					RootDiskSize:                 25,
+					BoshIp:                       "10.0.0.1",
 					EphemeralDiskSize:            25,
 					Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 					HourlyBillingFlag:            true,

--- a/softlayer/vm/softlayer_vm_test.go
+++ b/softlayer/vm/softlayer_vm_test.go
@@ -266,11 +266,11 @@ var _ = Describe("SoftLayerVM", func() {
 				"SoftLayer_Virtual_Guest_Service_getPowerState.json",
 				"SoftLayer_Virtual_Guest_Service_getActiveTransactions_None.json",
 				"SoftLayer_Virtual_Guest_Service_setMetadata.json",
+				"SoftLayer_Virtual_Guest_Service_getActiveTransactions_None.json",
 				"SoftLayer_Virtual_Guest_Service_configureMetadataDisk.json",
 				"SoftLayer_Virtual_Guest_Service_getPowerState.json",
 			}
 			testhelpers.SetTestFixturesForFakeSoftLayerClient(softLayerClient, fileNames)
-
 		})
 
 		It("attaches the iSCSI volume successfully (multipath-tool installed)", func() {
@@ -281,11 +281,13 @@ var _ = Describe("SoftLayerVM", func() {
 				"",
 				"",
 				"",
+				"",
 				expectedDmSetupLs1,
 			}
 			testhelpers.SetTestFixturesForFakeSSHClient(sshClient, expectedCmdResults, nil)
 			vm = NewSoftLayerVM(1234567, softLayerClient, sshClient, agentEnvService, logger, timeoutTransactionsDeleteVM)
 
+			bslcommon.PAUSE_TIME = 1 * time.Second
 			err := vm.AttachDisk(disk)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -298,11 +300,13 @@ var _ = Describe("SoftLayerVM", func() {
 				"",
 				"",
 				"",
+				"",
 				expectedPartitions2,
 			}
 			testhelpers.SetTestFixturesForFakeSSHClient(sshClient, expectedCmdResults, nil)
 			vm = NewSoftLayerVM(1234567, softLayerClient, sshClient, agentEnvService, logger, timeoutTransactionsDeleteVM)
 
+			bslcommon.PAUSE_TIME = 1 * time.Second
 			err := vm.AttachDisk(disk)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -315,11 +319,13 @@ var _ = Describe("SoftLayerVM", func() {
 				"",
 				"",
 				"",
+				"",
 				expectedDmSetupLs2,
 			}
 			testhelpers.SetTestFixturesForFakeSSHClient(sshClient, expectedCmdResults, nil)
 			vm = NewSoftLayerVM(1234567, softLayerClient, sshClient, agentEnvService, logger, timeoutTransactionsDeleteVM)
 
+			bslcommon.PAUSE_TIME = 1 * time.Second
 			err := vm.AttachDisk(disk)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -328,6 +334,7 @@ var _ = Describe("SoftLayerVM", func() {
 			testhelpers.SetTestFixturesForFakeSSHClient(sshClient, []string{"fake-result"}, errors.New("fake-error"))
 			vm = NewSoftLayerVM(1234567, softLayerClient, sshClient, agentEnvService, logger, timeoutTransactionsDeleteVM)
 
+			bslcommon.PAUSE_TIME = 1 * time.Second
 			err := vm.AttachDisk(disk)
 			Expect(err).To(HaveOccurred())
 		})
@@ -352,14 +359,15 @@ var _ = Describe("SoftLayerVM", func() {
 			fileNames := []string{
 				"SoftLayer_Virtual_Guest_Service_getObject.json",
 				"SoftLayer_Network_Storage_Service_getIscsiVolume.json",
+				"SoftLayer_Network_Storage_Service_getAllowedVirtualGuests.json",
+				"SoftLayer_Network_Storage_Service_removeAccessFromVirtualGuest.json",
 				"SoftLayer_Virtual_Guest_Service_getUserData_With_PersistentDisk.json",
 				"SoftLayer_Virtual_Guest_Service_getPowerState.json",
 				"SoftLayer_Virtual_Guest_Service_getActiveTransactions_None.json",
 				"SoftLayer_Virtual_Guest_Service_setMetadata.json",
+				"SoftLayer_Virtual_Guest_Service_getActiveTransactions_None.json",
 				"SoftLayer_Virtual_Guest_Service_configureMetadataDisk.json",
 				"SoftLayer_Virtual_Guest_Service_getPowerState.json",
-				"SoftLayer_Network_Storage_Service_getAllowedVirtualGuests.json",
-				"SoftLayer_Network_Storage_Service_removeAccessFromVirtualGuest.json",
 			}
 			testhelpers.SetTestFixturesForFakeSoftLayerClient(softLayerClient, fileNames)
 		})
@@ -373,6 +381,7 @@ var _ = Describe("SoftLayerVM", func() {
 			testhelpers.SetTestFixturesForFakeSSHClient(sshClient, expectedCmdResults, nil)
 			vm = NewSoftLayerVM(1234567, softLayerClient, sshClient, agentEnvService, logger, timeoutTransactionsDeleteVM)
 
+			bslcommon.PAUSE_TIME = 1 * time.Second
 			err := vm.DetachDisk(disk)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -387,6 +396,7 @@ var _ = Describe("SoftLayerVM", func() {
 			testhelpers.SetTestFixturesForFakeSSHClient(sshClient, expectedCmdResults, nil)
 			vm = NewSoftLayerVM(1234567, softLayerClient, sshClient, agentEnvService, logger, timeoutTransactionsDeleteVM)
 
+			bslcommon.PAUSE_TIME = 1 * time.Second
 			err := vm.DetachDisk(disk)
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -395,6 +405,7 @@ var _ = Describe("SoftLayerVM", func() {
 			testhelpers.SetTestFixturesForFakeSSHClient(sshClient, []string{"fake-result"}, errors.New("fake-error"))
 			vm = NewSoftLayerVM(1234567, softLayerClient, sshClient, agentEnvService, logger, timeoutTransactionsDeleteVM)
 
+			bslcommon.PAUSE_TIME = 1 * time.Second
 			err := vm.DetachDisk(disk)
 			Expect(err).To(HaveOccurred())
 		})


### PR DESCRIPTION
In order to make Softlayer eCPI compatible with bosh-init, we made lots of changes.

1. Please update godep workspace to include the latest changes from softlayer-go 
2. Please update godep workspace to include a new dependency "github.com/pivotal-golang/clock" 
3. I committed lots of godep workspace changes from my local workspace, please ignore them if not suitable