### PR TITLE
Fix create_vm integartion suite

### DIFF
--- a/integration/create_vm/create_vm_test.go
+++ b/integration/create_vm/create_vm_test.go
@@ -32,8 +32,8 @@ var _ = Describe("BOSH Director Level Integration for create_vm", func() {
 
 		rootTemplatePath, tmpConfigPath string
 		replacementMap                  map[string]string
-
-		output map[string]interface{}
+		errorOutput                     map[string]interface{}
+		resultOutput                    map[string]interface{}
 	)
 
 	BeforeEach(func() {
@@ -70,7 +70,20 @@ var _ = Describe("BOSH Director Level Integration for create_vm", func() {
 
 	Context("create_vm in SoftLayer", func() {
 
-		It("returns true because valid parameters", func() {
+		It("returns error because empty parameters", func() {
+			jsonPayload := `{"method": "create_vm", "arguments": [],"context": {}}`
+
+			outputBytes, err := testhelperscpi.RunCpi(rootTemplatePath, tmpConfigPath, jsonPayload)
+			log.Println("outputBytes=" + string(outputBytes))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = json.Unmarshal(outputBytes, &errorOutput)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(errorOutput["result"]).To(BeNil())
+			Expect(errorOutput["error"]).ToNot(BeNil())
+		})
+
+		It("returns valid result because valid parameters", func() {
 			jsonPayload, err := testhelperscpi.GenerateCpiJsonPayload("create_vm", rootTemplatePath, replacementMap)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -78,12 +91,12 @@ var _ = Describe("BOSH Director Level Integration for create_vm", func() {
 			log.Println("outputBytes=" + string(outputBytes))
 			Expect(err).ToNot(HaveOccurred())
 
-			err = json.Unmarshal(outputBytes, &output)
+			err = json.Unmarshal(outputBytes, &resultOutput)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(output["result"]).ToNot(BeNil())
-			Expect(output["error"]).To(BeNil())
+			Expect(resultOutput["result"]).ToNot(BeNil())
+			Expect(resultOutput["error"]).To(BeNil())
 
-			id := output["result"].(string)
+			id := resultOutput["result"].(string)
 			vmId, err := strconv.Atoi(id)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmId).ToNot(BeNil())
@@ -91,21 +104,5 @@ var _ = Describe("BOSH Director Level Integration for create_vm", func() {
 			testhelpers.DeleteVirtualGuest(vmId)
 		})
 
-	})
-
-	Context("create_vm in SoftLayer", func() {
-
-		It("returns false because empty parameters", func() {
-			jsonPayload := `{"method": "create_vm", "arguments": [],"context": {}}`
-
-			outputBytes, err := testhelperscpi.RunCpi(rootTemplatePath, tmpConfigPath, jsonPayload)
-			log.Println("outputBytes=" + string(outputBytes))
-			Expect(err).ToNot(HaveOccurred())
-
-			err = json.Unmarshal(outputBytes, &output)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(output["result"]).To(BeNil())
-			Expect(output["error"]).ToNot(BeNil())
-		})
 	})
 })

--- a/softlayer/vm/interface.go
+++ b/softlayer/vm/interface.go
@@ -8,6 +8,7 @@ import (
 )
 
 type VMCloudProperties struct {
+	Hostname                 string                               `json:"hostname,omitempty"`
 	Domain                   string                               `json:"domain,omitempty"`
 	StartCpus                int                                  `json:"startCpus,omitempty"`
 	MaxMemory                int                                  `json:"maxMemory,omitempty"`

--- a/softlayer/vm/softlayer_creator_test.go
+++ b/softlayer/vm/softlayer_creator_test.go
@@ -74,7 +74,7 @@ var _ = Describe("SoftLayerCreator", func() {
 					Datacenter:                   sldatatypes.Datacenter{Name: "fake-datacenter"},
 					HourlyBillingFlag:            true,
 					LocalDiskFlag:                true,
-					VmNamePrefix:                 "bosh-",
+					Hostname:                     "bosh-",
 					PostInstallScriptUri:         "",
 					DedicatedAccountHostOnlyFlag: true,
 					PrivateNetworkOnlyFlag:       false,

--- a/softlayer/vm/vm_utils.go
+++ b/softlayer/vm/vm_utils.go
@@ -43,7 +43,7 @@ func CreateVirtualGuestTemplate(agentID string, stemcell bslcstem.Stemcell, clou
 	base64EncodedMetadata := Base64EncodeData(string(metadataBytes))
 
 	virtualGuestTemplate := sldatatypes.SoftLayer_Virtual_Guest_Template{
-		Hostname:  cloudProps.VmNamePrefix,
+		Hostname:  cloudProps.Hostname,
 		Domain:    cloudProps.Domain,
 		StartCpus: cloudProps.StartCpus,
 		MaxMemory: cloudProps.MaxMemory,

--- a/test_fixtures/cpi_methods/create_vm.json
+++ b/test_fixtures/cpi_methods/create_vm.json
@@ -3,7 +3,7 @@
   "arguments": [
 	"45632666-9fb1-422a-af35-2ab6102c5c1b",
 	"651103", {
-	  "hostname": "ecpi_test",
+	  "hostname": "ecpitest",
 	  "domain": "softlayer.com",
 	  "startCpus": 1,
 	  "maxMemory": 1024,


### PR DESCRIPTION
This code fixes a problem in create_vm integration test, it always fails
with:

`Creating VirtualGuest from SoftLayer client: * Hostname for the
computing instance is required and cannot be empty`.

JSON template specified hostname as value of 'hostname' field but the
rest of the code expected it in 'VmPrefix' field. Finaly it should be
asigned to 'Hostname' field, so this fix harmonize naming by introducing
'Hostname' field in Go code.
Also value of 'hostname' in JSON was invalid, RFC doesn't allow to have
'_' in host names, SoftLayer API rejects such requests.
Small refactoring in spec code.