### PR TITLE
Fixed fatal error when updating user_data.json with process exist 1

### DIFF
--- a/dev/set_vm_metadata.json
+++ b/dev/set_vm_metadata.json
@@ -1,14 +1,14 @@
 {
   "method": "set_vm_metadata",
   "arguments": [
-	"10498259",
+    "14402229",
     {
-      "director": "5276b588-1016-4023-acae-9a0d797168be",
-      "name": "fake-director",
-      "tags": "test, tag, director"
+      "compiling": "buildpack_python",
+      "director": "bosh",
+      "deployment": "fake-test"
     }
   ],
   "context": {
-	"director_uuid": "5276b588-1016-4023-acae-9a0d797168be"
+    "director_uuid": "ee4a88be-e78f-4fe0-9e99-e458a2fa5d48"
   }
 }

--- a/integration/set_vm_metadata/set_vm_metadata_test.go
+++ b/integration/set_vm_metadata/set_vm_metadata_test.go
@@ -80,7 +80,7 @@ var _ = Describe("BOSH Director Level Integration for set_vm_metadata", func() {
 			replacementMap = map[string]string{
 				"ID":           strVGID,
 				"DirectorUuid": "fake-director-uuid",
-				"Tags":         "cpi-test, softlayer",
+				"Compiling":         "fake-package",
 			}
 		})
 

--- a/softlayer/vm/fs_agent_env_service.go
+++ b/softlayer/vm/fs_agent_env_service.go
@@ -8,6 +8,11 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 )
 
+const (
+	maxAttempts = 30
+	delay       = 10
+)
+
 type fsAgentEnvService struct {
 	softlayerFileService SoftlayerFileService
 	settingsPath         string
@@ -53,13 +58,13 @@ func (s fsAgentEnvService) Update(agentEnv AgentEnv) error {
 		return bosherr.WrapError(err, "Marshalling agent env")
 	}
 
-	for i := 0; i < 30; i++ {
+	for i := 0; i < maxAttempts; i++ {
 		s.logger.Debug(s.logTag, "Updating Agent Env: Making attempt #%d", i)
 		err = s.softlayerFileService.Upload(s.settingsPath, jsonBytes)
 		if err == nil {
 			return nil
 		}
-		time.Sleep(10 * time.Second)
+		time.Sleep(delay * time.Second)
 	}
 	return bosherr.WrapError(err, "Updating Agent Env timeout")
 }

--- a/softlayer/vm/softlayer_vm.go
+++ b/softlayer/vm/softlayer_vm.go
@@ -292,15 +292,21 @@ func (vm SoftLayerVM) DetachDisk(disk bslcdisk.Disk) error {
 // Private methods
 func (vm SoftLayerVM) extractTagsFromVMMetadata(vmMetadata VMMetadata) ([]string, error) {
 	tags := []string{}
+	status := ""
 	for key, value := range vmMetadata {
-		if key == "tags" {
-			stringValue, ok := value.(string)
-			if !ok {
+		if key == "compiling" || key == "job" || key == "index" || key == "deployment" {
+			stringValue, err := value.(string)
+			if !err {
 				return []string{}, bosherr.Errorf("Cannot convert tags metadata value `%v` to string", value)
 			}
 
-			tags = vm.parseTags(stringValue)
+			if status == "" {
+				status = key + ":" + stringValue
+			} else {
+				status = status + "," + key + ":" + stringValue
+			}
 		}
+		tags = vm.parseTags(status)
 	}
 
 	return tags, nil

--- a/softlayer/vm/softlayer_vm_test.go
+++ b/softlayer/vm/softlayer_vm_test.go
@@ -198,29 +198,37 @@ var _ = Describe("SoftLayerVM", func() {
 
 		Context("found tags in metadata", func() {
 			BeforeEach(func() {
-				metadataBytes := []byte(`{
-				  "director": "fake-director-uuid",
-				  "name": "fake-director",
-				  "tags": "test, tag, director"
-				}`)
-
-				metadata = bslvm.VMMetadata{}
-				err := json.Unmarshal(metadataBytes, &metadata)
-				Expect(err).ToNot(HaveOccurred())
-
 				softLayerClient.DoRawHttpRequestResponse = []byte("true")
 			})
 
 			It("the tags value is empty", func() {
-				metadata["tags"] = ""
-				err := vm.SetMetadata(metadata)
+				metadataBytes := []byte(`{
+				  "director": "fake-director-uuid",
+				  "fake1": "fake-deployment",
+				  "fake2": "buildpack_python"
+				}`)
+				metadata = bslvm.VMMetadata{}
+				err := json.Unmarshal(metadataBytes, &metadata)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = vm.SetMetadata(metadata)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(softLayerClient.DoRawHttpRequestResponseCount).To(Equal(0))
 			})
 
 			It("at least one tag found", func() {
-				err := vm.SetMetadata(metadata)
+				metadataBytes := []byte(`{
+				  "director": "fake-director-uuid",
+				  "deployment": "fake-deployment",
+				  "compiling": "buildpack_python"
+				}`)
+
+				metadata = bslvm.VMMetadata{}
+				err := json.Unmarshal(metadataBytes, &metadata)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = vm.SetMetadata(metadata)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(softLayerClient.DoRawHttpRequestResponseCount).To(Equal(1))
@@ -228,6 +236,16 @@ var _ = Describe("SoftLayerVM", func() {
 
 			Context("when SLVG.SetTags call fails", func() {
 				BeforeEach(func() {
+					metadataBytes := []byte(`{
+				      "director": "fake-director-uuid",
+				      "deployment": "fake-deployment",
+				      "compiling": "buildpack_python"
+				    }`)
+
+					metadata = bslvm.VMMetadata{}
+					err := json.Unmarshal(metadataBytes, &metadata)
+					Expect(err).ToNot(HaveOccurred())
+
 					softLayerClient.DoRawHttpRequestError = errors.New("fake-error")
 				})
 

--- a/test_fixtures/cpi_methods/set_vm_metadata.json
+++ b/test_fixtures/cpi_methods/set_vm_metadata.json
@@ -5,7 +5,7 @@
     {
       "director": "BOSH Director",
       "deployment": "softlayer",
-      "tags": "{{.Tags}}"
+      "compiling": "{{.Tags}}"
     }
   ],
   "context": {

--- a/util/ssh_client.go
+++ b/util/ssh_client.go
@@ -68,40 +68,34 @@ func (c *sshClientImpl) UploadFile(username string, password string, ip string, 
 
 	client, err := myssh.Dial("tcp", ip+":22", config)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	defer client.Close()
 
 	sftp, err := sftp.NewClient(client)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	defer sftp.Close()
 
 	data, err := ioutil.ReadFile(srcFile)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 
 	f, err := sftp.Create(destFile)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	defer f.Close()
 
 	_, err = f.Write([]byte(data))
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 
 	_, err = sftp.Lstat(destFile)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	return nil
@@ -125,34 +119,29 @@ func (c *sshClientImpl) DownloadFile(username string, password string, ip string
 
 	client, err := myssh.Dial("tcp", ip+":22", config)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	defer client.Close()
 
 	sftp, err := sftp.NewClient(client)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	defer sftp.Close()
 
 	pFile, err := sftp.Open(srcFile)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	defer pFile.Close()
 
 	data, err := ioutil.ReadAll(pFile)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 
 	err = ioutil.WriteFile(destFile, data, 0755)
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 

--- a/util/ssh_client.go
+++ b/util/ssh_client.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pkg/sftp"
 	myssh "golang.org/x/crypto/ssh"
 	"io/ioutil"
-	"log"
 	"regexp"
 )
 


### PR DESCRIPTION
When creating vm with ephemeral disk, CPI needs to ssh to deployed vm to do some configuration, and this PR is used to fix the ssh connection refused issue when updating user_data.json of bosh agent.